### PR TITLE
Add simple dashboard page

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Dashboard - Comicks</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-100">
+  <header class="p-4 bg-slate-800 text-white">
+    <h1 class="text-xl">Comicks Dashboard</h1>
+  </header>
+  <main class="p-4">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div class="p-4 bg-white rounded shadow">
+        <h2 class="text-lg mb-2">Comics Created</h2>
+        <p id="comicsCount" class="text-2xl font-bold">0</p>
+      </div>
+    </div>
+  </main>
+  <script>
+    // Demo statistic; in a real app this would come from persisted data
+    document.getElementById('comicsCount').textContent =
+      localStorage.getItem('comicsCount') || '0';
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone dashboard page with placeholder stats and Tailwind styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d5741ce48324a3dd780f6269961d